### PR TITLE
Fix crash when teleporting out of reality

### DIFF
--- a/patches/Terraclient/Terraria/Main.cs.patch
+++ b/patches/Terraclient/Terraria/Main.cs.patch
@@ -361,7 +361,7 @@
 +
 +				// Map teleportation cheat
 +				if (CheatHandler.GetCheat<MapTeleportCheat>().isEnabled && mouseRight)
-+					player[myPlayer].Teleport((mapFullscreenPos + new Vector2(mouseX - (screenWidth / 2), mouseY - (screenHeight / 2)) / 16 * 16 / mapFullscreenScale) * 16, TeleportationStyleID.DebugTeleport);
++					player[myPlayer].Teleport(new Vector2(Math.Min(Math.Max((Main.mapFullscreenPos.X + (float)(Main.mouseX - Main.screenWidth / 2) / Main.mapFullscreenScale) * 16f, 0f), (float)Main.maxTilesX * 16f - 64f), Math.Min(Math.Max((Main.mapFullscreenPos.Y + (float)(Main.mouseY - Main.screenHeight / 2) / Main.mapFullscreenScale) * 16f, 0f), (float)Main.maxTilesY * 16f - 64f)), TeleportationStyleID.DebugTeleport);
 +
  				DrawCursor(DrawThickCursor());
  			}


### PR DESCRIPTION
Changes Main.cs.patch in patches/Terraclient directory.
Simply, teleport to the nearest applicable place to the mouse.
Clamps the result of the map teleport to the map boundaries, plus some wiggle room since you can't have your foot sticking out of the map either, with a bit of a Vector2 formatting change I made while trying to understand what was going on.