### PR TITLE
Change how toolgod functions, add item modification marks

### DIFF
--- a/patches/Terraclient/Terraria/Terraclient/Cheats/CheatUtils.cs
+++ b/patches/Terraclient/Terraria/Terraclient/Cheats/CheatUtils.cs
@@ -35,81 +35,65 @@ namespace Terraria.Terraclient.Cheats
 			if (!CheatHandler.GetCheat<ToolGodCheat>().IsEnabled && !overrideCheatCheck)
 				return;
 
-			int i;
-			if (Main.mouseItem.pick < 0) {
-				i = 0;
-				for (; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].pick > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
-				Main.mouseItem.pick = ContentSamples.ItemsByType[ItemID.SolarFlarePickaxe].pick;
+			bool foundPick = false;
+			bool foundAxe = false;
+			bool foundHammer = false;
+			foreach (Item item in Main.LocalPlayer.inventory) {
+				if (!foundPick && item.pick > 0)
+					goto foundPick;
+				if (!foundAxe && item.axe > 0)
+					goto foundAxe;
+				if (!foundHammer && item.hammer > 0)
+					goto foundHammer;
+				if (item.pick > 0 || item.axe > 0 || item.hammer > 0) {
+					item.Refresh();
+					ResetItemName(item);
+				}
+				continue;
+			foundPick:
+				foundPick = true;
+				item.pick = 500;
+				if (!foundAxe && item.axe > 0)
+					goto foundAxe;
+				if (!foundHammer && item.hammer > 0)
+					goto foundHammer;
+				item.useTime = 0;
+				item.useAnimation = 7;
+				item.tileBoost = 15;
+				MarkItemAsModified(item);
+				continue;
+			foundAxe:
+				foundAxe = true;
+				item.axe = 100;
+				if (!foundHammer && item.hammer > 0)
+					goto foundHammer;
+				item.useTime = 0;
+				item.useAnimation = 7;
+				item.tileBoost = 15;
+				MarkItemAsModified(item);
+				continue;
+			foundHammer:
+				foundHammer = true;
+				item.hammer = 100;
+				item.useTime = 0;
+				item.useAnimation = 7;
+				item.tileBoost = 15;
+				MarkItemAsModified(item);
+			}
+			if (Main.mouseItem.pick > 0) {
+				Main.mouseItem.pick = 500;
+			}
+			if (Main.mouseItem.axe > 0) {
+				Main.mouseItem.axe = 100;
+			}
+			if (Main.mouseItem.hammer > 0) {
+				Main.mouseItem.hammer = 100;
+			}
+			if (Main.mouseItem.pick > 0 || Main.mouseItem.axe > 0 || Main.mouseItem.hammer > 0) {
 				Main.mouseItem.useTime = 0;
 				Main.mouseItem.useAnimation = 7;
 				Main.mouseItem.tileBoost = 15;
-			}
-			else {
-				for (i = 0; i < Main.player[Main.myPlayer].inventory.Length; i++) {
-					if (Main.player[Main.myPlayer].inventory[i].pick <= 0)
-						continue;
-
-					Main.player[Main.myPlayer].inventory[i].pick = ContentSamples.ItemsByType[2786].pick;
-					Main.player[Main.myPlayer].inventory[i].useTime = 0;
-					Main.player[Main.myPlayer].inventory[i].useAnimation = 7;
-					Main.player[Main.myPlayer].inventory[i].tileBoost = 15;
-					break;
-				}
-				for (i++; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].pick > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
-			}
-			if (Main.mouseItem.axe < 0) {
-				i = 0;
-				for (; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].axe > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
-				Main.mouseItem.axe = ContentSamples.ItemsByType[ItemID.SolarFlarePickaxe].axe;
-				Main.mouseItem.useTime = 0;
-				Main.mouseItem.useAnimation = 7;
-				Main.mouseItem.tileBoost = 15;
-			}
-			else {
-				for (i = 0; i < Main.player[Main.myPlayer].inventory.Length; i++) {
-					if (Main.player[Main.myPlayer].inventory[i].axe <= 0)
-						continue;
-
-					Main.player[Main.myPlayer].inventory[i].axe = ContentSamples.ItemsByType[2786].axe;
-					Main.player[Main.myPlayer].inventory[i].useTime = 0;
-					Main.player[Main.myPlayer].inventory[i].useAnimation = 7;
-					Main.player[Main.myPlayer].inventory[i].tileBoost = 15;
-					break;
-				}
-				for (i++; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].axe > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
-			}
-			if (Main.mouseItem.hammer < 0) {
-				i = 0;
-				for (; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].hammer > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
-				Main.mouseItem.hammer = ContentSamples.ItemsByType[ItemID.SolarFlarePickaxe].hammer;
-				Main.mouseItem.useTime = 0;
-				Main.mouseItem.useAnimation = 7;
-				Main.mouseItem.tileBoost = 15;
-			}
-			else {
-				for (i = 0; i < Main.player[Main.myPlayer].inventory.Length; i++) {
-					if (Main.player[Main.myPlayer].inventory[i].hammer <= 0)
-						continue;
-
-					Main.player[Main.myPlayer].inventory[i].hammer = ContentSamples.ItemsByType[2786].hammer;
-					Main.player[Main.myPlayer].inventory[i].useTime = 0;
-					Main.player[Main.myPlayer].inventory[i].useAnimation = 7;
-					Main.player[Main.myPlayer].inventory[i].tileBoost = 15;
-					break;
-				}
-				for (i++; i < Main.player[Main.myPlayer].inventory.Length; i++)
-					if (Main.player[Main.myPlayer].inventory[i].hammer > 0)
-						Main.player[Main.myPlayer].inventory[i].Refresh();
+				MarkItemAsModified(Main.mouseItem);
 			}
 		}
 
@@ -164,8 +148,26 @@ namespace Terraria.Terraclient.Cheats
 			Recipe.FindRecipes();
 		}
 
-		public static void MarkItemAsModified(Item item) => item.SetNameOverride(item.AffixName() + "*");
+		public static void MarkItemAsModified(Item item) => item.SetNameOverride(ContentSamples.ItemsByType[item.type].AffixName() + "*");
 
 		public static void ResetItemName(Item item) => item.ClearNameOverride();
+
+		public static void ResetItemNames() {
+			Item[][] arr = {
+				Main.LocalPlayer.inventory,
+				Main.LocalPlayer.armor,
+				Main.LocalPlayer.dye,
+				Main.LocalPlayer.miscEquips,
+				Main.LocalPlayer.miscDyes,
+				Main.LocalPlayer.bank.item,
+				Main.LocalPlayer.bank2.item,
+				Main.LocalPlayer.bank3.item,
+				Main.LocalPlayer.bank4.item
+			};
+
+			for (int i = 0; i < arr.Length; i++)
+				for (int j = 0; j < arr[i].Length; j++)
+					ResetItemName(arr[i][j]);
+		}
 	}
 }

--- a/patches/Terraclient/Terraria/Terraclient/Commands/MystagogueCommand.cs
+++ b/patches/Terraclient/Terraria/Terraclient/Commands/MystagogueCommand.cs
@@ -161,6 +161,7 @@ namespace Terraria.Terraclient.Commands
 				.AddParameters(new List<CommandArgument>())
 				.AddAction(_ => {
 					Main.mouseItem.Refresh();
+					CheatUtils.ResetItemName(Main.mouseItem);
 					CheatUtils.ToolGodBuffMyTools();
 					CheatCommandUtils.Output(false, Language.GetTextValue("CommandOutputs.ri_Succ"));
 				})
@@ -170,6 +171,7 @@ namespace Terraria.Terraclient.Commands
 				.AddParameters(new List<CommandArgument>())
 				.AddAction(_ => {
 					Main.player[Main.myPlayer].RefreshItems();
+					CheatUtils.ResetItemNames();
 					CheatUtils.ToolGodBuffMyTools();
 					CheatCommandUtils.Output(false, Language.GetTextValue("CommandOutputs.ris_Succ"));
 				})


### PR DESCRIPTION
Toolgod no longer checks the mouse item, then the rest of the inventory. Toolgod now checks the inventory and ignores the mouse item at first, the checks the mouse item and buffs it as if no other tools of its sort were buffed yet.